### PR TITLE
Requested Fixes 01/25/24

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,8 +1,8 @@
 <footer class="footer secondary-font" role="contentinfo">	
     <small style="padding:1em">
-        <a href="https://github.com/Distance-Over-Time" aria-label="Link to our studio's GitHub Organization"><img class="footer-icon" src="{{ site.social_media_icons['GitHub'] }}" alt="GitHub"></a>
-        <a href="https://bsky.app/profile/distanceovertime.bsky.social" arial-label="Link to our studio's Bluesky"><img class="footer-icon" src="{{ site.social_media_icons['Bluesky'] }}" alt="Bluesky"></a>
+        <a target="_blank" rel="noopener" href="https://github.com/Distance-Over-Time" aria-label="Link to our studio's GitHub Organization"><img class="footer-icon" src="{{ site.social_media_icons['GitHub'] }}" alt="GitHub"></a>
+        <a target="_blank" rel="noopener" href="https://bsky.app/profile/distanceovertime.bsky.social" arial-label="Link to our studio's Bluesky"><img class="footer-icon" src="{{ site.social_media_icons['Bluesky'] }}" alt="Bluesky"></a>
         <span>|</span>
-        <a class="general" href="https://github.com/Distance-Over-Time/distance-over-time.github.io">Repo & Credits</a>
+        <a class="general" target="_blank" rel="noopener" href="https://github.com/Distance-Over-Time/distance-over-time.github.io">Repo & Credits</a>
     </small>
 </footer>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -103,7 +103,7 @@ layout: default
         {% assign icon = site.social_media_icons[platform] %}
   
         {% if icon %}
-          <a href="{{ url }}" aria-label="link to {{ platform }}"><img src="{{ icon }}" alt="{{ platform }}" class="social-icon no-hover"></a>
+          <a target="_blank" rel="noopener" href="{{ url }}" aria-label="link to {{ platform }}"><img src="{{ icon }}" alt="{{ platform }}" class="social-icon no-hover"></a>
         {% endif %}
       {% endfor %}  
     </section>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -55,7 +55,7 @@ layout: default
           {% assign platform = link.platform %}
           {% assign url = link.url %}
           {% assign icon = site.social_media_icons[platform] %}
-            <a href="{{ url }}" alt="{{ platform }}">
+            <a target="_blank" rel="noopener" href="{{ url }}" alt="{{ platform }}">
             <img src="{{ icon }}" class="social-icon" aria-label="link to {{ platform }}" alt="{{ platform }} logo"></a>
         {% endfor %}
       </div>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -56,7 +56,7 @@ layout: default
           {% assign url = link.url %}
           {% assign icon = site.social_media_icons[platform] %}
             <a href="{{ url }}" alt="{{ platform }}">
-            <img src="{{ icon }}" class="social-icon" aria-label="link to {{ page.platform }}" alt="{{ platform }} logo"></a>
+            <img src="{{ icon }}" class="social-icon" aria-label="link to {{ platform }}" alt="{{ platform }} logo"></a>
         {% endfor %}
       </div>
     </section>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -12,7 +12,7 @@ layout: default
     <article role="article" class="card">
 	    <a class="card-text" href="{{ site.baseurl }}{{ project.url }}">
       <div class="meta">
-        <h1 class="main-font card-project-name">{{ project.title }}</h1>
+        <h2 class="main-font card-project-name">{{ project.title }}</h2>
         <p class="secondary-font">{{ project.summary }}</p>
         <time class="date secondary-font" datetime="{{ project.date | date_to_xmlschema }}">{{ project.date | date: "%Y" }} &middot; {{ project.category }}</time>
       </div>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,7 +4,7 @@ title: About
 ---
 <h1 class="page-title">Who We Are</h1>
 
-Formed from the <a class="general" href="https://www.igdafoundation.org/virtualexchange">International Game Developers Association Foundation</a>’s (IGDA-F) Virtual Exchange in 2023, the ***Distance Over Time Studio (DOTS)*** consists of members of the program’s Velocity cohort, marginalized game developers trying to transition into the video game industry from a different field.
+Formed from the <a class="general" target="_blank" rel="noopener" href="https://www.igdafoundation.org/virtualexchange">International Game Developers Association Foundation</a>’s (IGDA-F) Virtual Exchange in 2023, the ***Distance Over Time Studio (DOTS)*** consists of members of the program’s Velocity cohort, marginalized game developers trying to transition into the video game industry from a different field.
 
 What started as mutual support for each other to reach our goals has transformed into a passion-fueled studio that aims to diversify gaming from those who create it to the stories those games tell. Our mission is to create accessible games that bring the representation we want to experience more of while we learn something new along the way. 
 

--- a/_posts/2024-01-01-Sai.md
+++ b/_posts/2024-01-01-Sai.md
@@ -21,7 +21,7 @@ socials:
 ---
 
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - Composer
 - Sound designer
 - Narrative
@@ -29,7 +29,7 @@ Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itc
 <hr class="secondary">
 
 ##### _Guiding Light (2023)_
-Links: [DOTs Page](/projects/guiding-light) &middot; [Itch.io](https://candlesticklibrary.itch.io/guiding-light)
+Links: [DOTs Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 - Composer
 - Sound Designer
 - Narrative

--- a/_posts/2024-01-01-allison-darcy-mitteer.md
+++ b/_posts/2024-01-01-allison-darcy-mitteer.md
@@ -19,6 +19,6 @@ socials:
 ---
 
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - Narrative Lead
 - Writer

--- a/_posts/2024-01-01-anzal.md
+++ b/_posts/2024-01-01-anzal.md
@@ -21,5 +21,5 @@ socials:
 ---
 
 ##### _Inn for the Lost (2023)_
-[DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - Ideation and design 

--- a/_posts/2024-01-01-ashley-phipps.md
+++ b/_posts/2024-01-01-ashley-phipps.md
@@ -7,7 +7,7 @@ image: ashley_phipps.jpg
 alt: Headshot of Ashley Phipps. She is wearing pink headphones with decorative cat ears on them and several plushies are in the background.
 roles: Producer, Lead Producer
 role_icons: [Producer]
-summary: Ashley is a producer and community manager for DOTs.  She is also a cozy (though occasionally chaotic) games streamer on Twitch and mother to an (also chaotic) toddler!
+summary: Ashley is a producer and community manager for DOTS.  She is also a cozy (though occasionally chaotic) games streamer on Twitch and mother to an (also chaotic) toddler!
 projects: [Guiding Light, Inn for the Lost]
 portfolio: https://ashleyphipps.me/
 contact:
@@ -28,13 +28,13 @@ socials:
     url: https://www.twitch.tv/shleedelie
 ---
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - Lead Producer
 
 <hr class="secondary">
 
 ##### _Guiding Light (2023)_
-Links: [DOTs Page](/projects/guiding-light) &middot; [Itch.io](https://candlesticklibrary.itch.io/guiding-light)
+Links: [DOTS Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 - Producer
 - Narrative Editor
 - UI Design

--- a/_posts/2024-01-01-jacob-wheeler.md
+++ b/_posts/2024-01-01-jacob-wheeler.md
@@ -19,7 +19,7 @@ socials:
 ---
 
 ##### _Guiding Light (2023)_
-Links: [DOTs Page](/projects/guiding-light) &middot; [Itch.io](https://candlesticklibrary.itch.io/guiding-light)
+Links: [DOTs Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 - Designed and implemented levels 1-4 from blockout to final launch layout, and aesthetic passes including elements of sound design, verticality, conveyance, and descriptive environmental triggers for screen-reader implementation
 - Collaborated with the sound design and programming teams to prototype an accessibility audio indicator system for obstacles, environmental hazards, collectables, and enemies for our blind-player audience
 - Prototyped a compass system with UI components to assist players in world navigation

--- a/_posts/2024-01-01-jenn-duan.md
+++ b/_posts/2024-01-01-jenn-duan.md
@@ -21,7 +21,7 @@ socials:
 ---
 
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - Lead UI Designer
 - Character Artist (sketch concepts, lineart, coloring)
 - Copy editing of narrative script

--- a/_posts/2024-01-01-mikaela_carino.md
+++ b/_posts/2024-01-01-mikaela_carino.md
@@ -19,7 +19,7 @@ socials:
 ---
 
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - C++ and Blueprint programming for the below (mainly Blueprints)
 - Heavily customized the “Visual Novel Framework” project in Unreal Engine 5.1
 - Implement system to toggle text-to-speech and save this setting on a per-user basis
@@ -30,7 +30,7 @@ Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itc
 <hr class="secondary">
 
 ##### _Guiding Light (2023)_
-Links: [DOTs Page](/projects/guiding-light) &middot; [Itch.io](https://candlesticklibrary.itch.io/guiding-light)
+Links: [DOTs Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 ###### *Current Work*
 - C++ and Blueprint programming for the below (mainly C++)
 - Character movement/inputs

--- a/_posts/2024-01-01-monkey-kg.md
+++ b/_posts/2024-01-01-monkey-kg.md
@@ -22,7 +22,7 @@ socials:
     url: https://bsky.app/profile/monkeykg.bsky.social
 ---
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - Character design assistance
 - sprite design assistance
 - Background editing assistance 
@@ -30,7 +30,7 @@ Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itc
 <hr class="secondary">
 
 ##### _Guiding Light (2023)_
-Links: [DOTs Page](/projects/guiding-light) &middot; [Itch.io](https://candlesticklibrary.itch.io/guiding-light)
+Links: [DOTs Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 - Character design
 - Character/item sprite assets
 - CG design

--- a/_posts/2024-01-01-oksana-starshova.md
+++ b/_posts/2024-01-01-oksana-starshova.md
@@ -19,6 +19,6 @@ socials:
 ---
 
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - QA Lead
 - Games User Researcher

--- a/_posts/2024-01-01-ross-minor.md
+++ b/_posts/2024-01-01-ross-minor.md
@@ -30,7 +30,7 @@ socials:
     url: https://mastodon.social/@RossMinor
 ---
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - Researched and collaborated with the team to integrate TTS throughout the game
 - Helped design and provide guidance for features such as in-game descriptions, font size, and color contrast
 - Worked with QA to conduct user tests to determine accessibility pain points for blind players
@@ -38,7 +38,7 @@ Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itc
 <hr class="secondary">
 
 ##### _Guiding Light (2023)_
-Links: [DOTs Page](/projects/guiding-light) &middot; [Itch.io](https://candlesticklibrary.itch.io/guiding-light)
+Links: [DOTs Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 - Helped design a navigation system to allow blind players to explore the game independently
 - Advised on accessibility best practices surrounding navigation, sound design, and more
 - Created an audio glossary to help blind players learn the sounds of the game

--- a/_posts/2024-01-01-ryan-davis.md
+++ b/_posts/2024-01-01-ryan-davis.md
@@ -25,7 +25,7 @@ socials:
 ---
 
 ##### _Inn for the Lost (2023)_
-Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itch.io/inn-for-the-lost)
+Links: [DOTs Page](/projects/inn-lost) &middot; <a target="_blank" rel="noopener" href="https://shleedelie.itch.io/inn-for-the-lost">Itch.io</a>
 - Art team manager
 - 2D sprite work
 - 3D backgrounds
@@ -33,6 +33,7 @@ Links: [DOTs Page](/projects/inn-lost) &middot; [Itch.io](https://shleedelie.itc
 <hr class="secondary">
 
 ##### _Guiding Light (2023)_
+Links: [DOTs Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 - Dialogue system development
 - 3D shaders
 - Unreal Blueprint optimization

--- a/_posts/2024-01-01-sophie-galley.md
+++ b/_posts/2024-01-01-sophie-galley.md
@@ -25,7 +25,7 @@ socials:
 ---
 
 ##### _Guiding Light (2023)_
-Links: [DOTs Page](/projects/guiding-light) &middot; [Itch.io](https://candlesticklibrary.itch.io/guiding-light)
+Links: [DOTs Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 - Managed and organized accessible schedule and kanban board with Taylor McElroy and Ashley Phipps to maintain and fulfill milestones and visualize production status
 - Spearheaded and ran 1:1 playtests with the aid of Ross Minor, Ashley Phipps, and Taylor McElroy
 - Created Google Forms and Google sheets to track potential playtester information for current and future playtests

--- a/_posts/2024-01-01-taylor-mcelroy.md
+++ b/_posts/2024-01-01-taylor-mcelroy.md
@@ -21,7 +21,7 @@ socials:
 ---
 
 ##### _Guiding Light (2023)_
-Links: [DOTs Page](/projects/guiding-light) &middot; [Itch.io](https://candlesticklibrary.itch.io/guiding-light)
+Links: [DOTs Page](/projects/guiding-light) &middot; <a target="_blank" rel="noopener" href="https://candlesticklibrary.itch.io/guiding-light">Itch.io</a>
 - Lead Producer
 - Team meeting facilitation and note-taking
 - Utilized Miro for task-tracking and project deadlines

--- a/_projects/2023-10-31-guiding-light.md
+++ b/_projects/2023-10-31-guiding-light.md
@@ -48,6 +48,6 @@ team:
 
 *Navigate the ominous realm of the dead in this blind-accessible, narrative-driven game about death and what comes after. Guided by their cheeky gatekeeper, newly-deceased Uri must track down their missing memories in 3 eerie levels of the afterlife.*
 
-***Guiding Light*** is a blind-accessible top-down, narrative-driven adventure game originally produced for [Themed Horror Game Jam #15 - Halloween Edition](https://itch.io/jam/themed-horror-game-jam-15).
+***Guiding Light*** is a blind-accessible top-down, narrative-driven adventure game originally produced for <a target="_blank" rel="noopener" href="https://itch.io/jam/themed-horror-game-jam-15">Themed Horror Game Jam #15 - Halloween Edition</a>.
 
-Patches are in development for a future submission to [The Rookies](https://www.therookies.co/).
+Patches are in development for a future submission to <a target="_blank" rel="noopener" href="https://www.therookies.co">The Rookies</a>.

--- a/_projects/2023-12-31-inn-lost.md
+++ b/_projects/2023-12-31-inn-lost.md
@@ -3,7 +3,7 @@ layout: project
 title: Inn For The Lost
 logo: /assets/images/proj/iftl/iftl_logo.png
 alt: The outline of a house with a patio and chimney with text reading "Inn for the Lost."
-summary: Visual novel accessible to all players
+summary: Visual novel with a focus on accessibility
 category: Visual Novel
 demo: https://shleedelie.itch.io/inn-for-the-lost
 links:

--- a/_projects/2023-12-31-inn-lost.md
+++ b/_projects/2023-12-31-inn-lost.md
@@ -48,4 +48,4 @@ team:
 
 *You are the innkeeper of a mountain lodge where magical creatures of all kinds congregate when they need to find...something. You'll meet and make warm drinks for a variety of patrons while trying to unravel the mystery of the unending snow storm that has trapped everyone inside.*
 
-***Inn for the Lost*** is a blind-accessible visual novel originally produced for [Winter VN Jam 2023](https://itch.io/jam/winter-vn-jam-2023).
+***Inn for the Lost*** is a blind-accessible visual novel originally produced for <a target="_blank" rel="noopener" href="https://itch.io/jam/winter-vn-jam-2023">Winter VN Jam 2023</a>.

--- a/_sass/_fonts.scss
+++ b/_sass/_fonts.scss
@@ -18,6 +18,7 @@ h5, h6 {
   text-shadow: 1px 1px 0px #0397D5,
                1px 2px 0px #0397D5
 }
+
 .main-font {
   font-family: 'Genos';
   color: black;
@@ -28,14 +29,15 @@ h5, h6 {
 }
 
 .profile-name {
-  font-size: 3rem;
+  font-size: 2rem;
   text-shadow: 1px 1px 0px #0397D5,
                1px 2px 0px #0397D5
 }
 
 .card-project-name {
-  font-size: 2rem;
+  font-size: 2rem !important;
   text-transform: uppercase;
+  padding-bottom: 0.5rem;
 }
 
 .profile-section-title {
@@ -72,4 +74,16 @@ h5, h6 {
   text-decoration-color:#0397D5;
 }
 
-
+@media only screen and (max-width: 600px) {
+  .page-title {
+    font-size: 205%;
+    color: #000000;
+    text-shadow: 0.5px 0.5px 0px #0397D5,
+                 0.5px 1.5px 0px #0397D5
+  }
+  
+  .card-project-name {
+    font-size: 1.5rem !important;
+    padding-bottom: 0rem;
+  }
+}

--- a/_sass/_fonts.scss
+++ b/_sass/_fonts.scss
@@ -29,7 +29,7 @@ h5, h6 {
 }
 
 .profile-name {
-  font-size: 2rem;
+  font-size: 3rem;
   text-shadow: 1px 1px 0px #0397D5,
                1px 2px 0px #0397D5
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -390,6 +390,12 @@ a.general:hover {
 }
 
 @media only screen and (max-width: 600px) {
+  html {
+    box-sizing: border-box;
+    margin:10px; 
+    padding:0;
+  }
+
   .game-logo {
     max-width: 300px;
   }


### PR DESCRIPTION
# Requested Fixes | Jan. 25, 2024
### Requested Fixes
- Added Ashley's portfolio (pushed to `main` directly)
- Fixed Taylor's bio image from `jpg` to `png` again (pushed to `main` directly)
- Changed IFTL description verbiage to "Visual novel with a focus on accessibility"
- Fixed `arial-labels` in Liquid Markdown to properly add icon names to screen reader text for social media icons on project pages
- Changed project titles on `projects.html` to be `h2` instead of `h1` for SEO
- First pass at having all external hyperlinks open a new tab

### Additions:
- Mobile: added `html` margins so things wouldn't look so squished
- Mobile: shrunk page titles to avoid line breaks
- Boosted size of profile name text (Desktop)